### PR TITLE
Nested fields

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 black = "*"
 numpy = "*"
+coverage = "*"
 
 [dev-packages]
 

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ A `Message` object can be created by:
 		"pad": Bits(3, value="000"),
 		"crc": lambda ptr, addr, pad: EKMS32Bit(ptr, addr, pad)
 	},
-	"FILL_KEY": {
+	"SQUIRT_THING": {
 		"id": Nibbles(4, value="0015"),
 		"ptr": Bytes(3),
 		"addr": Bits(2),
 		"pad": Bits(4, value="0000"),
-		"crc": lambda ptr, addr, pad: EKMS32Bit(ptr, addr, pad)
+		"crc": lambda ptr, addr, pad: CRC32Bit(ptr, addr, pad)
 	}
 }
 ```

--- a/pymessagelib/_exceptions.py
+++ b/pymessagelib/_exceptions.py
@@ -1,0 +1,24 @@
+'''
+Created on Feb 18, 2021
+
+@author: smalb
+'''
+
+class InvalidFieldException(Exception):
+    pass
+
+
+class InvalidFieldDataException(Exception):
+    pass
+
+
+class MissingFieldDataException(Exception):
+    pass
+
+
+class InvalidDataFormatException(Exception):
+    pass
+
+
+class ContextDataMismatchException(Exception):
+    pass

--- a/pymessagelib/field.py
+++ b/pymessagelib/field.py
@@ -1,0 +1,285 @@
+'''
+Created on Feb 18, 2021
+
+@author: smalb
+'''
+
+from abc import ABC
+from enum import Enum
+import math
+import inspect
+
+from _exceptions import InvalidDataFormatException, ContextDataMismatchException
+
+class Field(ABC):
+    
+    class Format(Enum):
+        Bin = 2
+        Oct = 8
+        Dec = 10
+        Hex = 16
+        
+    def __init__(self, length, value=None, format=None, context=None):
+        self._context = context
+        self._unit_length = length
+        self._bit_length = length * type(self).bits_per_unit
+        self._format = None
+        self._value_function = None
+        self._value = None
+        self._access = {
+            "Read": True,
+            "Write": True if value is None else False,
+            "Auto Update": inspect.isfunction(value),
+        }
+
+        # Determine the format the value will be rendered
+        if format:
+            self._format = format
+        elif value is not None and not inspect.isfunction(value):
+            self._format = Field.get_format(value)
+        else:
+            self._format = Field.Format.Bin if "Bit" in type(self).__name__ else Field.Format.Hex
+
+        # Determine if the value is a function or an actual value.
+        if inspect.isfunction(value):
+            self._value_function = value
+        elif value is not None:
+            assert self.value_is_valid(value)
+            self._value = self.render(value=value, fmt=Field.Format.Bin, pad_to_length=self._bit_length)
+            assert len(self._value) - 1 == self._bit_length
+
+    def render(self, value=None, fmt=None, pad_to_length=0) -> str:
+        from message import Message
+        
+        if not value:
+            value = self.value
+        if not fmt:
+            fmt = self._format
+        pad_to_length = pad_to_length if pad_to_length > 0 else math.ceil(self._bit_length / math.log2(fmt.value))
+        if isinstance(value, Message):
+            return value.render()
+        else:
+            return Field.render_value(value=value, fmt=fmt, pad_to_length=pad_to_length)
+    
+    @staticmethod
+    def render_value(*, value, fmt, pad_to_length):
+        prefix, numeric_value = value[0], value[1:]
+        int_val = int(numeric_value, Field.bases()[prefix].value)
+        fmt_str = f"0{pad_to_length}{Field.inverted_bases()[fmt]}"
+        return Field.inverted_bases()[fmt] + format(int_val, fmt_str)
+
+    def value_is_valid(self, value):
+        bin_value = self.render(value=value, fmt=Field.Format.Bin, pad_to_length=self._bit_length)[1:]
+        if len(bin_value) == self._bit_length:
+            return True
+        return False
+    
+    def length_as_format(self, fmt):
+        return math.ceil(self._bit_length / math.log2(fmt.value))
+
+    @property
+    def value_updater(self):
+        return self._value_function
+
+    @property
+    def is_readable(self):
+        return self._access["Read"]
+
+    @property
+    def is_writable(self):
+        return self._access["Write"]
+
+    @property
+    def is_auto_updated(self):
+        return self._access["Auto Update"]
+
+    @property
+    def value(self):
+        if self.context:
+            return self.context.from_data(self._value)
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        from message import Message
+        
+        is_msg = False
+        if isinstance(value, Message):
+            is_msg = True
+            context = type(value)
+            value = value.render()
+        if self.value_is_valid(value):
+            self._value = value
+            if is_msg:
+                self.context = context
+        else:
+            raise Exception() # TODO: raise more narrow exception
+
+    @property
+    def context(self):
+        return self._context
+
+    @context.setter
+    def context(self, context):
+        from message import Message
+        
+        assert Message in inspect.getmro(context) or context is None
+        
+        if context is None:
+            self._context = context
+        else:
+            try:
+                context.from_data(self._value)
+            except InvalidDataFormatException:
+                raise ContextDataMismatchException(
+                    f"The data '{self._value}' is not compatible with context {context.__name__}"
+                )
+            else:
+                self._context = context
+            
+    def __repr__(self):
+        if self.value:
+            return self.render()
+        else:
+            return f'<{type(self).__name__} Field, length={self._unit_length} ({len(self)} bits), value=undefined>'
+
+    def __eq__(self, other):
+
+        if isinstance(other, Field):
+            return self.__eq__(other._value)
+
+        self_prefix, self_numeric_value = self._value[0], self._value[1:]
+        self_int_val = int(self_numeric_value, Field.bases()[self_prefix].value)
+
+        other_prefix, other_numeric_value = other[0], other[1:]
+        other_int_val = int(other_numeric_value, Field.bases()[other_prefix].value)
+
+        return self_int_val == other_int_val
+
+    def __lt__(self, other):
+        pass
+
+    def __bytes__(self):
+        pass
+
+    def __call__(self):
+        pass
+
+    def __len__(self):
+        return self._bit_length
+
+    def __contains__(self):
+        pass
+
+    def __getitem__(self):
+        pass
+
+    def __setitem__(self, value):
+        pass
+
+    def __add__(self, other):
+        pass
+
+    def __sub__(self, other):
+        pass
+
+    def __lshift__(self, amount):
+        pass
+
+    def __rshift__(self, amount):
+        pass
+
+    def __and__(self, other):
+        pass
+
+    def __rand__(self, other):
+        pass
+
+    def __xor__(self, other):
+        pass
+
+    def __rxor__(self, other):
+        pass
+
+    def __or__(self, other):
+        pass
+
+    def __ror__(self, other):
+        pass
+
+    def __int__(self):
+        pass
+
+    def __invert__(self):
+        bin_val = self.render(fmt=Field.Format.Bin)
+        inv_bin_val = bin_val.replace("0", "_").replace("1", "0").replace("_", "0")
+        inv_val = Field.render(value=inv_bin_val, fmt=self._format)
+        newfield = type(self).__new__()
+        newfield.__init__(self.length_as_format(self._format), value=inv_val, format=self._format)
+        return newfield
+
+    def __bool__(self):
+        return "1" in self.render(Field.Format.Bin)
+
+    ######################################################
+    # Static Methods
+    ######################################################
+
+    @staticmethod
+    def bases():
+        return {
+            "b": Field.Format.Bin,
+            "o": Field.Format.Oct,
+            "d": Field.Format.Dec,
+            "x": Field.Format.Hex,
+        }
+
+    @staticmethod
+    def inverted_bases():
+        return {v: k for k, v in Field.bases().items()}
+
+    @staticmethod
+    def get_format(value):
+        return Field.bases()[value[0]]
+
+    @staticmethod
+    def pad_to_length(value, length):
+        prefix = value[0]
+        numeric_value = value[1:]
+        if len(numeric_value) <= length:
+            padding = "0" * (length - len(numeric_value))
+            return f"{prefix}{padding}{numeric_value}"
+        else:
+            raise Exception("Value is already longer than padding length")
+
+
+class Bits(Field):
+    bits_per_unit = 1
+
+
+class Nibbles(Field):
+    bits_per_unit = 4
+
+
+class Bytes(Field):
+    bits_per_unit = 8
+
+
+class Words(Field):
+    bits_per_unit = 16
+
+
+class DWords(Field):
+    bits_per_unit = 32
+
+
+class QWords(Field):
+    bits_per_unit = 64
+
+
+Bit = Bits
+Nibble = Nibbles
+Byte = Bytes
+Word = Words
+DWord = DWords
+QWord = QWords

--- a/pymessagelib/message.py
+++ b/pymessagelib/message.py
@@ -6,293 +6,11 @@ Created on Jan 9, 2021
 
 from abc import ABC
 import inspect
-from enum import Enum
 from typing import Dict
 from copy import deepcopy
-import math
 
-############
-# Exceptions
-############
-
-
-class InvalidFieldException(Exception):
-    pass
-
-
-class InvalidFieldDataException(Exception):
-    pass
-
-
-class MissingFieldDataException(Exception):
-    pass
-
-
-class InvalidDataFormatException(Exception):
-    pass
-
-
-class ContextDataMismatchException(Exception):
-    pass
-
-
-###########################################################################
-# Field Class
-###########################################################################
-
-
-class Field(ABC):
-    class Format(Enum):
-        Bin = 2
-        Oct = 8
-        Dec = 10
-        Hex = 16
-
-    def __init__(self, length, value=None, format=None, context=None):
-        self._context = context
-        self._unit_length = length
-        self._bit_length = length * type(self).bits_per_unit
-        self._format = None
-        self._value_function = None
-        self._value = None
-        self._access = {
-            "Read": True,
-            "Write": True if value is None else False,
-            "Auto Update": inspect.isfunction(value),
-        }
-
-        # Determine the format the value will be rendered
-        if format:
-            self._format = format
-        elif value is not None and not inspect.isfunction(value):
-            self._format = Field.get_format(value)
-        else:
-            self._format = Field.Format.Bin if "Bit" in type(self).__name__ else Field.Format.Hex
-
-        # Determine how many characters to display when displaying in default format
-        self._character_length = math.ceil(self._bit_length / math.log2(self._format.value))
-
-        # Determine if the value is a function or an actual value.
-        if inspect.isfunction(value):
-            self._value_function = value
-        elif value is not None:
-            assert self.value_is_valid(value)
-            self._value = self.render(value=value, fmt=Field.Format.Bin, pad_to_length=self._bit_length)
-            assert len(self._value) - 1 == self._bit_length
-
-    def render(self, value=None, fmt=None, pad_to_length=0) -> str:
-        if not value:
-            value = self.value
-        if not fmt:
-            fmt = self._format
-        pad_to_length = pad_to_length if pad_to_length > 0 else self._character_length
-        return Field.render_value(value=value, fmt=fmt, pad_to_length=pad_to_length)
-    
-    @staticmethod
-    def render_value(*, value, fmt, pad_to_length):
-        prefix, numeric_value = value[0], value[1:]
-        int_val = int(numeric_value, Field.bases()[prefix].value)
-        fmt_str = f"0{pad_to_length}{Field.inverted_bases()[fmt]}"
-        return Field.inverted_bases()[fmt] + format(int_val, fmt_str)
-
-    def value_is_valid(self, value):
-        bin_value = self.render(value=value, fmt=Field.Format.Bin, pad_to_length=self._bit_length)[1:]
-        if len(bin_value) == self._bit_length:
-            return True
-        return False
-
-    @property
-    def value_updater(self):
-        return self._value_function
-
-    @property
-    def is_readable(self):
-        return self._access["Read"]
-
-    @property
-    def is_writable(self):
-        return self._access["Write"]
-
-    @property
-    def is_auto_updated(self):
-        return self._access["Auto Update"]
-
-    @property
-    def value(self):
-        if self.context:
-            return self.context.from_data(self._value)
-        return self._value
-
-    @value.setter
-    def value(self, value):
-        assert self.value_is_valid(value)
-        self._value = value
-
-    @property
-    def context(self):
-        return self._context
-
-    @context.setter
-    def context(self, context):
-        assert isinstance(context, Message)
-        try:
-            self.context.from_data(self._value)
-        except InvalidDataFormatException:
-            raise ContextDataMismatchException(
-                f"The data '{self._value}' is not compatible with context {context.__name__}"
-            )
-
-    def __repr__(self):
-        if self.value:
-            return self.render()
-        else:
-            return f'<{type(self).__name__} Field, length={self._unit_length} ({len(self)} bits), value=undefined>'
-
-    def __eq__(self, other):
-
-        if isinstance(other, Field):
-            return self.__eq__(other._value)
-
-        self_prefix, self_numeric_value = self._value[0], self._value[1:]
-        self_int_val = int(self_numeric_value, Field.bases()[self_prefix].value)
-
-        other_prefix, other_numeric_value = other[0], other[1:]
-        other_int_val = int(other_numeric_value, Field.bases()[other_prefix].value)
-
-        return self_int_val == other_int_val
-
-    def __lt__(self, other):
-        pass
-
-    def __bytes__(self):
-        pass
-
-    def __call__(self):
-        pass
-
-    def __len__(self):
-        return self._bit_length
-
-    def __contains__(self):
-        pass
-
-    def __getitem__(self):
-        pass
-
-    def __setitem__(self, value):
-        pass
-
-    def __add__(self, other):
-        pass
-
-    def __sub__(self, other):
-        pass
-
-    def __lshift__(self, amount):
-        pass
-
-    def __rshift__(self, amount):
-        pass
-
-    def __and__(self, other):
-        pass
-
-    def __rand__(self, other):
-        pass
-
-    def __xor__(self, other):
-        pass
-
-    def __rxor__(self, other):
-        pass
-
-    def __or__(self, other):
-        pass
-
-    def __ror__(self, other):
-        pass
-
-    def __int__(self):
-        pass
-
-    def __invert__(self):
-        bin_val = self.render(fmt=Field.Format.Bin)
-        inv_bin_val = bin_val.replace("0", "_").replace("1", "0").replace("_", "0")
-        inv_val = Field.render(value=inv_bin_val, fmt=self._format)
-        newfield = type(self).__new__()
-        newfield.__init__(self._character_length, value=inv_val, format=self._format)
-        return newfield
-
-    def __bool__(self):
-        return "1" in self.render(Field.Format.Bin)
-
-    ######################################################
-    # Static Methods
-    ######################################################
-
-    @staticmethod
-    def bases():
-        return {
-            "b": Field.Format.Bin,
-            "o": Field.Format.Oct,
-            "d": Field.Format.Dec,
-            "x": Field.Format.Hex,
-        }
-
-    @staticmethod
-    def inverted_bases():
-        return {v: k for k, v in Field.bases().items()}
-
-    @staticmethod
-    def get_format(value):
-        return Field.bases()[value[0]]
-
-    @staticmethod
-    def pad_to_length(value, length):
-        prefix = value[0]
-        numeric_value = value[1:]
-        if len(numeric_value) <= length:
-            padding = "0" * (length - len(numeric_value))
-            return f"{prefix}{padding}{numeric_value}"
-        else:
-            raise Exception("Value is already longer than padding length")
-
-
-class Bits(Field):
-    bits_per_unit = 1
-
-
-class Nibbles(Field):
-    bits_per_unit = 4
-
-
-class Bytes(Field):
-    bits_per_unit = 8
-
-
-class Words(Field):
-    bits_per_unit = 16
-
-
-class DWords(Field):
-    bits_per_unit = 32
-
-
-class QWords(Field):
-    bits_per_unit = 64
-
-
-Bit = Bits
-Nibble = Nibbles
-Byte = Bytes
-Word = Words
-DWord = DWords
-QWord = QWords
-
-###########################################################################
-# Message Class
-###########################################################################
-
+from field import Field
+from _exceptions import InvalidDataFormatException
 
 class Message(ABC):
     """
@@ -305,6 +23,7 @@ class Message(ABC):
         # Fields need to be deep copied so the same field objects aren't shared
         # across all message instances of the same type.
         self._fields = deepcopy(fields)  # maps field names to field objects
+        self._parent_field = None
 
     @staticmethod
     def _create_setter(name, field):
@@ -323,9 +42,26 @@ class Message(ABC):
 
         def get_field(self):
             field = self._fields[name]
-            return field
+            if field.context is not None:
+                msg = field.value
+                msg._parent_field = field
+                return msg
+            else:
+                return field
 
         return get_field
+    
+    @property
+    def context(self):
+        if self._parent_field is not None:
+            return self._parent_field.context
+        else:
+            return None
+
+    @context.setter
+    def context(self, context):
+        assert self._parent_field is not None
+        self._parent_field.context = context
 
     def update_fields(self):
         # Update all auto-update fields
@@ -347,6 +83,10 @@ class Message(ABC):
                 raise Exception("Circular field dependency detected!")
             elif not try_again:
                 break
+            
+    def render(self):
+        bin_data = f"b{''.join([data.render(fmt=Field.Format.Bin)[1:] for data in self._fields.values()])}"
+        return Field.render_value(value=bin_data, fmt=Field.Format.Hex, pad_to_length=len(self)//4)
 
     def render_table(self, formats=(Field.Format.Hex, Field.Format.Bin)) -> str:
 
@@ -412,100 +152,18 @@ class Message(ABC):
 
     @classmethod
     def from_data(cls, data):
-        # TODO: Chunk up the data and instantiate a new object with populated fields.
         # 1. Convert the data to binary
         binary_data = Field.render_value(value=data, fmt=Field.Format.Bin, pad_to_length=cls.bit_length)[1:]
         
         # 2. chunk into fields
         writable_field_data = {}
         for fieldname, field in cls.format.items():
-            print(field)
             if field.is_writable:
                 writable_field_data[fieldname] = f'b{binary_data[:len(field)]}'
             binary_data = binary_data[len(field):]
-            
-        print(writable_field_data)
         
         # 3. Construct a new message providing data only for writable fields.
-        return cls(**writable_field_data)
-        
-        #try:
-        #    
-        #except:
-        #    raise InvalidDataFormatException(f"the data '{data}' doesn't fit the format for '{cls.__name__}'")
-
-
-###########################################################################
-# MessageBuilder Class
-###########################################################################
-
-
-class MessageBuilder:
-    """
-    The message builder dynamically creates message classes given valid message formats.
-    """
-
-    def build_message_classes(self, msg_format_dict):
-        """
-        :param msg_format_dict: Maps message names to formats. The formats are a dictionary that follows the structure defined in the README.md
-        :type msg_format_dict: Dict
-        """
-        messages = {}
-        for msg_name, msg_format in msg_format_dict.items():
-            messages[msg_name] = self.build_message_class(msg_name, msg_format)
-        return messages
-
-    def build_message_class(self, cls_name, fmt):
-
-        # Create an empty class with the appropriate name that inherits from Message.
-        msg_cls = type(cls_name, (Message,), {})
-
-        # Categorize the fields to generate methods appropriately
-        all_fields = {}
-        writable_fields = {}
-        read_only_fields = {}
-        auto_updated_fields = {}
-        for name, item in fmt.items():
-            if isinstance(item, Field):
-                all_fields[name] = item
-                if item.is_writable:
-                    writable_fields[name] = item
-                if item.is_readable:
-                    read_only_fields[name] = item
-                if item.is_auto_updated:
-                    auto_updated_fields[name] = item
-
-        def __init__(self, **kwargs):
-            Message.__init__(self, all_fields)
-
-            # Verify values for all writable fields were provided via params
-            for field_name in writable_fields:
-                if field_name not in kwargs:
-                    raise MissingFieldDataException(
-                        f"A value must be provided for the '{field_name}' field upon instantiation"
-                    )
-
-            # initialize writable fields from parameters
-            for param, val in kwargs.items():
-                if param in all_fields:
-                    if msg_cls.format[param].value_is_valid(val):
-                        self._fields[param].value = val
-                    else:
-                        raise InvalidFieldDataException(
-                            f"'{val}' is not a valid value for the field '{param}' in message '{cls_name}'"
-                        )
-                else:
-                    raise InvalidFieldException(f"'{param}' is not a valid field in the {cls_name} message.")
-
-            self.update_fields()
-
-        # Make a getter for all fields and a setter only for writable fields
-        for name, field in all_fields.items():
-            getter = Message._create_getter(name)
-            setter = Message._create_setter(name, field) if name in writable_fields else None
-            setattr(msg_cls, name, property(getter, setter))
-
-        msg_cls.__init__ = __init__
-        msg_cls.format = fmt
-        msg_cls.bit_length = sum((len(field) for field in fmt.values()))
-        return msg_cls
+        try:
+            return cls(**writable_field_data)
+        except Exception as e: # TODO: Narrow exception handling
+            raise InvalidDataFormatException(f"the data '{data}' doesn't fit the format for '{cls.__name__}'")

--- a/pymessagelib/message_builder.py
+++ b/pymessagelib/message_builder.py
@@ -1,0 +1,87 @@
+'''
+Created on Feb 18, 2021
+
+@author: smalb
+'''
+
+from message import Message
+from field import Field
+
+from _exceptions import MissingFieldDataException, InvalidFieldException, InvalidFieldDataException
+
+class MessageBuilder:
+    """
+    The message builder dynamically creates message classes given valid message formats.
+    """
+
+    def build_message_classes(self, msg_format_dict):
+        """
+        :param msg_format_dict: Maps message names to formats. The formats are a dictionary that follows the structure defined in the README.md
+        :type msg_format_dict: Dict
+        """
+        messages = {}
+        for msg_name, msg_format in msg_format_dict.items():
+            messages[msg_name] = self.build_message_class(msg_name, msg_format)
+        return messages
+
+    def build_message_class(self, cls_name, fmt):
+
+        # Create an empty class with the appropriate name that inherits from Message.
+        msg_cls = type(cls_name, (Message,), {})
+
+        # Categorize the fields to generate methods appropriately
+        all_fields = {}
+        writable_fields = {}
+        read_only_fields = {}
+        auto_updated_fields = {}
+        for name, item in fmt.items():
+            if isinstance(item, Field):
+                all_fields[name] = item
+                if item.is_writable:
+                    writable_fields[name] = item
+                if item.is_readable:
+                    read_only_fields[name] = item
+                if item.is_auto_updated:
+                    auto_updated_fields[name] = item
+
+        def __init__(self, **kwargs):
+            Message.__init__(self, all_fields)
+
+            # Verify values for all writable fields were provided via params
+            for field_name in writable_fields:
+                if field_name not in kwargs:
+                    raise MissingFieldDataException(
+                        f"A value must be provided for the '{field_name}' field upon instantiation"
+                    )
+
+            # initialize writable fields from parameters
+            for param, val in kwargs.items():
+                if param in all_fields:
+                    context = None
+                    if isinstance(val, Message):
+                        context = type(val)
+                        val = val.render()
+                        
+                    if msg_cls.format[param].value_is_valid(val):
+                        self._fields[param].value = val
+                        if context:
+                            self._fields[param].context = context
+                    else:
+                        raise InvalidFieldDataException(
+                            f"'{val}' is not a valid value for the field '{param}' in message '{cls_name}'"
+                        )
+                else:
+                    raise InvalidFieldException(f"'{param}' is not a valid field in the {cls_name} message.")
+
+            self.update_fields()
+
+        # Make a getter for all fields and a setter only for writable fields
+        for name, field in all_fields.items():
+            getter = Message._create_getter(name)
+            setter = Message._create_setter(name, field) if name in writable_fields else None
+            setattr(msg_cls, name, property(getter, setter))
+
+        msg_cls.__init__ = __init__
+        msg_cls.format = fmt
+        msg_cls.bit_length = sum((len(field) for field in fmt.values()))
+        return msg_cls

--- a/pymessagelib/test.py
+++ b/pymessagelib/test.py
@@ -4,8 +4,8 @@ Created on Feb 8, 2021
 @author: smalb
 """
 import unittest
-from message import MessageBuilder
-from message import Nibbles, Bytes, Bits, Bit, Byte
+from message_builder import MessageBuilder
+from field import Nibbles, Bytes, Bits, Bit, Byte
 
 msg_fmts = {
     "GET_ADDR": {
@@ -133,7 +133,7 @@ class TestFields(unittest.TestCase):
 
         def verify_msg_outputs(msg):
             assert msg.data.context == OUTPUTS
-            assert type(msg.data.value) == OUTPUTS
+            assert type(msg.data) == OUTPUTS
             assert msg.data.reset1 == "b1"
             assert msg.data.reset2 == "b0"
             assert msg.data.cautions == "x00"
@@ -141,14 +141,14 @@ class TestFields(unittest.TestCase):
 
         def verify_msg_inputs(msg):
             assert msg.data.context == INPUTS
-            assert type(msg.data.value) == INPUTS
+            assert type(msg.data) == INPUTS
             assert msg.data.service_req == "b1"
             assert msg.data.voltage_ready == "b0"
             assert msg.data.exit_code == "x0000"
             assert msg.data.last_command_mid == "x0"
             assert msg.data.unused == "x00"
 
-        send_msg_1 = WRITE_REGISTER_REQUEST(addr="x60000001", data="x10000000")
+        send_msg_1 = WRITE_REGISTER_REQUEST(addr="x60000001", data="x80000000")
         send_msg_1.data.context = OUTPUTS
         verify_msg_outputs(send_msg_1)
         send_msg_1.data.context = INPUTS


### PR DESCRIPTION
Implements #2 (nested-fields)

A field can now hold a `context`, which is a Message class that adds an additional layer of meaning to the field. Internally, the context is just stored as a class separate from the value. When the field is accessed, a new instance of the context is created and returned.

```python
msg = WRITE_REGISTER_REQUEST(addr="x60000001", data="x80000000")
msg.data.context = OUTPUTS
assert msg.data.context == OUTPUTS
assert type(msg.data) == OUTPUTS
assert msg.data.reset1 == "b1"
assert msg.data.reset2 == "b0"
assert msg.data.cautions == "x00"
assert msg.data.unused == "x0"
```